### PR TITLE
Bugfixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Geopoto
+#Geophoto
 
 The project showcases how to store a variety of data structures in a MarkLogic (NoSQL Document Management) database. The application uses JSON documents with geospatial data, binary documents (JPEG image files) as well as RDF Triple data.
 
@@ -34,7 +34,7 @@ It is assumed that you already have the MarkLogic Server installed. If you requi
 Geophoto uses Node.js to call the [Management API](http://docs.marklogic.com/REST/management) to set up the application server and databases needed. To run this script, change directories to `ml-setup`, then run `node setup.js`. 
 
     cd ml-setup
-    node setup.js
+    node setup.js bootstrap
 
 > Note that `setup.js` assumes a default local installation, where the Management API is available at http://localhost:8002. If deploying to a remote server, or if you need to change the admin username or password, edit setup.js before running. 
 

--- a/sjs/countries.sjs
+++ b/sjs/countries.sjs
@@ -33,10 +33,11 @@ var filterString = 'FILTER(langMatches(lang(?abstract), "EN"))';
 
 var sparqlQuery = xdmp.urlEncode(prefixes + 'CONSTRUCT {' + constructString + ' } WHERE { ' + whereString + filterString + ' }');
 var endpoint = 'http://dbpedia.org/sparql?query=';
-var qFinal = fn.concat(endpoint, sparqlQuery);
+var suffix = '&format=text%2Fplain';
+var qFinal = fn.concat(endpoint, sparqlQuery, suffix); 
 var dbPediaResponse = xdmp.httpGet(qFinal);
 var header = dbPediaResponse.next();
 var dbPediaTriples = dbPediaResponse.next();
-var triplesForInsert = sem.rdfParse(dbPediaTriples.value, 'turtle');
+var triplesForInsert = sem.rdfParse(dbPediaTriples.value, 'ntriple');
 
 sem.rdfInsert(triplesForInsert, null, null, 'country-data');


### PR DESCRIPTION
Some simple cleanup to the readme.

Also, countries.sjs was receiving binary content from DBpedia, so sem.rdfParse choked as it expects a string.  Updated call to DBpedia with format so that text is returned and rdfParse parses n-triples instead of turtle now.
