### PR TITLE
Changing port to 8010 to be more Docker friendly.

### DIFF
--- a/dbsettings.js
+++ b/dbsettings.js
@@ -2,7 +2,7 @@
 
 var connection = {
     host: 'localhost',
-    port: 5003,
+    port: 8010,
     user: 'admin',
     password: 'admin'
 };

--- a/import/import.js
+++ b/import/import.js
@@ -7,7 +7,7 @@ var marklogic = require('marklogic');
 var path = require('path');
 var connection = {
   host: 'localhost',
-  port: 5003,
+  port: 8010,
   user: 'admin',
   password: 'admin'
 };

--- a/ml-setup/01-rest-instance-config.json
+++ b/ml-setup/01-rest-instance-config.json
@@ -1,11 +1,11 @@
 {
   "rest-api":
   {
-    "name": "5003-geophoto",
+    "name": "8010-geophoto",
     "group": "Default",
     "database": "geophoto-content",
     "modules-database": "geophoto-modules",
-    "port": "5003",
+    "port": "8010",
     "forests-per-host": 1
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "main": "app.js",
   "scripts": {
+    "setup": "node ml-setup/setup.js bootstrap",
+    "import": "cd import; node import.js ../data/photos; cd ..",
+    "wipe": "node ml-setup/setup.js wipe",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "node ./node_modules/bower/bin/bower install"
   },

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Before executing the script please make sure that you open the file `connection.
 
 	var connection = {
 	  host: "localhost",
-	  port: 5003,
+	  port: 8010,
 	  user: "admin",
 	  password: "admin"
 	};
@@ -75,7 +75,7 @@ Before starting the application please make sure that you have the right connect
 
 	var connection = {
 	    host: 'localhost',
-	    port: 5003,
+	    port: 8010,
 	    user: 'admin',
 	    password: 'admin'
 	};

--- a/views/partials/importfiles.jade
+++ b/views/partials/importfiles.jade
@@ -17,7 +17,7 @@
 
     var connection = {
         host: 'localhost',
-        port: 5003,
+        port: 8010,
         user: 'admin',
         password: 'admin'
     };


### PR DESCRIPTION
When mapping ports for a Docker image, we can specify a range. Need
to include 8000-8002; 5003-8002 is too big of a range.